### PR TITLE
Fix horizontal and vertical bar runes on Windows

### DIFF
--- a/widgets/framed/framed.go
+++ b/widgets/framed/framed.go
@@ -31,7 +31,7 @@ var (
 
 func init() {
 	if runtime.GOOS == "windows" {
-		UnicodeFrame = FrameRunes{'┌', '┐', '└', '┘', '―', '―', '|', '|'}
+		UnicodeFrame = FrameRunes{'┌', '┐', '└', '┘', '─', '─', '│', '│'}
 		UnicodeAltFrame = UnicodeFrame
 	}
 }


### PR DESCRIPTION
On Windows, Gowid currently uses plain ASCII characters for drawing the horizontal and vertical lines on frames, rather than your typical box-drawing characters.  This change replaces the ASCII horizontal/vertical bars with standard box-drawing runes on Windows.