### PR TITLE
Updated tutorial4 code to match example

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -219,7 +219,7 @@ func (w *QuestionBox) UserInput(ev interface{}, size gowid.IRenderSize, focus go
 		case tcell.KeyEnter:
 			w.IWidget = text.New(fmt.Sprintf("Nice to meet you, %s.\n\nPress Q to exit.", w.IWidget.(*edit.Widget).Text()))
 		default:
-			res = gowid.UserInput(w.IWidget, ev, size, focus, app)
+			res = w.IWidget.UserInput(w.IWidget, ev, size, focus, app)
 		}
 	}
 	return res


### PR DESCRIPTION
The code in `examples/gowid-tutorial4` works correctly, but the corresponding code in `Tutorial.md` – while it also works – doesn't match it. Since the package level `UserInput` function hasn't been introduced yet by this point the tutorial, I think it makes more sense to use `w.IWidget.UserInput` here.