### PR TITLE
Refactor to tcell/v2

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -825,7 +825,7 @@ func (a *App) initScreen() error {
 		defBg = IColorToTCell(bgCol, defBg, a.GetColorMode())
 		defSt = defSt.MergeUnder(style)
 	}
-	defStyle := tcell.Style(defSt.OnOff).Background(defBg.ToTCell()).Foreground(defFg.ToTCell())
+	defStyle := tcell.Style{}.Attributes(defSt.OnOff).Background(defBg.ToTCell()).Foreground(defFg.ToTCell())
 	// Ask TCell to set the screen's default style according to the palette's "default"
 	// config, if one is provided. This might make every screen cell underlined, for example,
 	// in the absence of overriding styling from widgets.

--- a/canvas.go
+++ b/canvas.go
@@ -11,7 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/mattn/go-runewidth"
 	"github.com/pkg/errors"
 )

--- a/decoration.go
+++ b/decoration.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/lucasb-eyer/go-colorful"
 	"github.com/pkg/errors"
@@ -627,263 +627,263 @@ var (
 	}
 
 	term256 = []TCellColor{
-		MakeTCellColorExt(tcell.Color(0)),
-		MakeTCellColorExt(tcell.Color(1)),
-		MakeTCellColorExt(tcell.Color(2)),
-		MakeTCellColorExt(tcell.Color(3)),
-		MakeTCellColorExt(tcell.Color(4)),
-		MakeTCellColorExt(tcell.Color(5)),
-		MakeTCellColorExt(tcell.Color(6)),
-		MakeTCellColorExt(tcell.Color(7)),
-		MakeTCellColorExt(tcell.Color(8)),
-		MakeTCellColorExt(tcell.Color(9)),
-		MakeTCellColorExt(tcell.Color(10)),
-		MakeTCellColorExt(tcell.Color(11)),
-		MakeTCellColorExt(tcell.Color(12)),
-		MakeTCellColorExt(tcell.Color(13)),
-		MakeTCellColorExt(tcell.Color(14)),
-		MakeTCellColorExt(tcell.Color(15)),
+		MakeTCellColorExt(tcell.ColorBlack),
+		MakeTCellColorExt(tcell.ColorMaroon),
+		MakeTCellColorExt(tcell.ColorGreen),
+		MakeTCellColorExt(tcell.ColorOlive),
+		MakeTCellColorExt(tcell.ColorNavy),
+		MakeTCellColorExt(tcell.ColorPurple),
+		MakeTCellColorExt(tcell.ColorTeal),
+		MakeTCellColorExt(tcell.ColorSilver),
+		MakeTCellColorExt(tcell.ColorGray),
+		MakeTCellColorExt(tcell.ColorRed),
+		MakeTCellColorExt(tcell.ColorLime),
+		MakeTCellColorExt(tcell.ColorYellow),
+		MakeTCellColorExt(tcell.ColorBlue),
+		MakeTCellColorExt(tcell.ColorFuchsia),
+		MakeTCellColorExt(tcell.ColorAqua),
+		MakeTCellColorExt(tcell.ColorWhite),
 		//
-		MakeTCellColorExt(tcell.Color(16)),
-		MakeTCellColorExt(tcell.Color(17)),
-		MakeTCellColorExt(tcell.Color(18)),
-		MakeTCellColorExt(tcell.Color(19)),
-		MakeTCellColorExt(tcell.Color(20)),
-		MakeTCellColorExt(tcell.Color(21)),
-		MakeTCellColorExt(tcell.Color(22)),
-		MakeTCellColorExt(tcell.Color(23)),
-		MakeTCellColorExt(tcell.Color(24)),
-		MakeTCellColorExt(tcell.Color(25)),
-		MakeTCellColorExt(tcell.Color(26)),
-		MakeTCellColorExt(tcell.Color(27)),
-		MakeTCellColorExt(tcell.Color(28)),
-		MakeTCellColorExt(tcell.Color(29)),
-		MakeTCellColorExt(tcell.Color(30)),
-		MakeTCellColorExt(tcell.Color(31)),
-		MakeTCellColorExt(tcell.Color(32)),
-		MakeTCellColorExt(tcell.Color(33)),
-		MakeTCellColorExt(tcell.Color(34)),
-		MakeTCellColorExt(tcell.Color(35)),
-		MakeTCellColorExt(tcell.Color(36)),
-		MakeTCellColorExt(tcell.Color(37)),
-		MakeTCellColorExt(tcell.Color(38)),
-		MakeTCellColorExt(tcell.Color(39)),
-		MakeTCellColorExt(tcell.Color(40)),
-		MakeTCellColorExt(tcell.Color(41)),
-		MakeTCellColorExt(tcell.Color(42)),
-		MakeTCellColorExt(tcell.Color(43)),
-		MakeTCellColorExt(tcell.Color(44)),
-		MakeTCellColorExt(tcell.Color(45)),
-		MakeTCellColorExt(tcell.Color(46)),
-		MakeTCellColorExt(tcell.Color(47)),
-		MakeTCellColorExt(tcell.Color(48)),
-		MakeTCellColorExt(tcell.Color(49)),
-		MakeTCellColorExt(tcell.Color(50)),
-		MakeTCellColorExt(tcell.Color(51)),
-		MakeTCellColorExt(tcell.Color(52)),
-		MakeTCellColorExt(tcell.Color(53)),
-		MakeTCellColorExt(tcell.Color(54)),
-		MakeTCellColorExt(tcell.Color(55)),
-		MakeTCellColorExt(tcell.Color(56)),
-		MakeTCellColorExt(tcell.Color(57)),
-		MakeTCellColorExt(tcell.Color(58)),
-		MakeTCellColorExt(tcell.Color(59)),
-		MakeTCellColorExt(tcell.Color(60)),
-		MakeTCellColorExt(tcell.Color(61)),
-		MakeTCellColorExt(tcell.Color(62)),
-		MakeTCellColorExt(tcell.Color(63)),
-		MakeTCellColorExt(tcell.Color(64)),
-		MakeTCellColorExt(tcell.Color(65)),
-		MakeTCellColorExt(tcell.Color(66)),
-		MakeTCellColorExt(tcell.Color(67)),
-		MakeTCellColorExt(tcell.Color(68)),
-		MakeTCellColorExt(tcell.Color(69)),
-		MakeTCellColorExt(tcell.Color(70)),
-		MakeTCellColorExt(tcell.Color(71)),
-		MakeTCellColorExt(tcell.Color(72)),
-		MakeTCellColorExt(tcell.Color(73)),
-		MakeTCellColorExt(tcell.Color(74)),
-		MakeTCellColorExt(tcell.Color(75)),
-		MakeTCellColorExt(tcell.Color(76)),
-		MakeTCellColorExt(tcell.Color(77)),
-		MakeTCellColorExt(tcell.Color(78)),
-		MakeTCellColorExt(tcell.Color(79)),
-		MakeTCellColorExt(tcell.Color(80)),
-		MakeTCellColorExt(tcell.Color(81)),
-		MakeTCellColorExt(tcell.Color(82)),
-		MakeTCellColorExt(tcell.Color(83)),
-		MakeTCellColorExt(tcell.Color(84)),
-		MakeTCellColorExt(tcell.Color(85)),
-		MakeTCellColorExt(tcell.Color(86)),
-		MakeTCellColorExt(tcell.Color(87)),
-		MakeTCellColorExt(tcell.Color(88)),
-		MakeTCellColorExt(tcell.Color(89)),
-		MakeTCellColorExt(tcell.Color(90)),
-		MakeTCellColorExt(tcell.Color(91)),
-		MakeTCellColorExt(tcell.Color(92)),
-		MakeTCellColorExt(tcell.Color(93)),
-		MakeTCellColorExt(tcell.Color(94)),
-		MakeTCellColorExt(tcell.Color(95)),
-		MakeTCellColorExt(tcell.Color(96)),
-		MakeTCellColorExt(tcell.Color(97)),
-		MakeTCellColorExt(tcell.Color(98)),
-		MakeTCellColorExt(tcell.Color(99)),
-		MakeTCellColorExt(tcell.Color(100)),
-		MakeTCellColorExt(tcell.Color(101)),
-		MakeTCellColorExt(tcell.Color(102)),
-		MakeTCellColorExt(tcell.Color(103)),
-		MakeTCellColorExt(tcell.Color(104)),
-		MakeTCellColorExt(tcell.Color(105)),
-		MakeTCellColorExt(tcell.Color(106)),
-		MakeTCellColorExt(tcell.Color(107)),
-		MakeTCellColorExt(tcell.Color(108)),
-		MakeTCellColorExt(tcell.Color(109)),
-		MakeTCellColorExt(tcell.Color(110)),
-		MakeTCellColorExt(tcell.Color(111)),
-		MakeTCellColorExt(tcell.Color(112)),
-		MakeTCellColorExt(tcell.Color(113)),
-		MakeTCellColorExt(tcell.Color(114)),
-		MakeTCellColorExt(tcell.Color(115)),
-		MakeTCellColorExt(tcell.Color(116)),
-		MakeTCellColorExt(tcell.Color(117)),
-		MakeTCellColorExt(tcell.Color(118)),
-		MakeTCellColorExt(tcell.Color(119)),
-		MakeTCellColorExt(tcell.Color(120)),
-		MakeTCellColorExt(tcell.Color(121)),
-		MakeTCellColorExt(tcell.Color(122)),
-		MakeTCellColorExt(tcell.Color(123)),
-		MakeTCellColorExt(tcell.Color(124)),
-		MakeTCellColorExt(tcell.Color(125)),
-		MakeTCellColorExt(tcell.Color(126)),
-		MakeTCellColorExt(tcell.Color(127)),
-		MakeTCellColorExt(tcell.Color(128)),
-		MakeTCellColorExt(tcell.Color(129)),
-		MakeTCellColorExt(tcell.Color(130)),
-		MakeTCellColorExt(tcell.Color(131)),
-		MakeTCellColorExt(tcell.Color(132)),
-		MakeTCellColorExt(tcell.Color(133)),
-		MakeTCellColorExt(tcell.Color(134)),
-		MakeTCellColorExt(tcell.Color(135)),
-		MakeTCellColorExt(tcell.Color(136)),
-		MakeTCellColorExt(tcell.Color(137)),
-		MakeTCellColorExt(tcell.Color(138)),
-		MakeTCellColorExt(tcell.Color(139)),
-		MakeTCellColorExt(tcell.Color(140)),
-		MakeTCellColorExt(tcell.Color(141)),
-		MakeTCellColorExt(tcell.Color(142)),
-		MakeTCellColorExt(tcell.Color(143)),
-		MakeTCellColorExt(tcell.Color(144)),
-		MakeTCellColorExt(tcell.Color(145)),
-		MakeTCellColorExt(tcell.Color(146)),
-		MakeTCellColorExt(tcell.Color(147)),
-		MakeTCellColorExt(tcell.Color(148)),
-		MakeTCellColorExt(tcell.Color(149)),
-		MakeTCellColorExt(tcell.Color(150)),
-		MakeTCellColorExt(tcell.Color(151)),
-		MakeTCellColorExt(tcell.Color(152)),
-		MakeTCellColorExt(tcell.Color(153)),
-		MakeTCellColorExt(tcell.Color(154)),
-		MakeTCellColorExt(tcell.Color(155)),
-		MakeTCellColorExt(tcell.Color(156)),
-		MakeTCellColorExt(tcell.Color(157)),
-		MakeTCellColorExt(tcell.Color(158)),
-		MakeTCellColorExt(tcell.Color(159)),
-		MakeTCellColorExt(tcell.Color(160)),
-		MakeTCellColorExt(tcell.Color(161)),
-		MakeTCellColorExt(tcell.Color(162)),
-		MakeTCellColorExt(tcell.Color(163)),
-		MakeTCellColorExt(tcell.Color(164)),
-		MakeTCellColorExt(tcell.Color(165)),
-		MakeTCellColorExt(tcell.Color(166)),
-		MakeTCellColorExt(tcell.Color(167)),
-		MakeTCellColorExt(tcell.Color(168)),
-		MakeTCellColorExt(tcell.Color(169)),
-		MakeTCellColorExt(tcell.Color(170)),
-		MakeTCellColorExt(tcell.Color(171)),
-		MakeTCellColorExt(tcell.Color(172)),
-		MakeTCellColorExt(tcell.Color(173)),
-		MakeTCellColorExt(tcell.Color(174)),
-		MakeTCellColorExt(tcell.Color(175)),
-		MakeTCellColorExt(tcell.Color(176)),
-		MakeTCellColorExt(tcell.Color(177)),
-		MakeTCellColorExt(tcell.Color(178)),
-		MakeTCellColorExt(tcell.Color(179)),
-		MakeTCellColorExt(tcell.Color(180)),
-		MakeTCellColorExt(tcell.Color(181)),
-		MakeTCellColorExt(tcell.Color(182)),
-		MakeTCellColorExt(tcell.Color(183)),
-		MakeTCellColorExt(tcell.Color(184)),
-		MakeTCellColorExt(tcell.Color(185)),
-		MakeTCellColorExt(tcell.Color(186)),
-		MakeTCellColorExt(tcell.Color(187)),
-		MakeTCellColorExt(tcell.Color(188)),
-		MakeTCellColorExt(tcell.Color(189)),
-		MakeTCellColorExt(tcell.Color(190)),
-		MakeTCellColorExt(tcell.Color(191)),
-		MakeTCellColorExt(tcell.Color(192)),
-		MakeTCellColorExt(tcell.Color(193)),
-		MakeTCellColorExt(tcell.Color(194)),
-		MakeTCellColorExt(tcell.Color(195)),
-		MakeTCellColorExt(tcell.Color(196)),
-		MakeTCellColorExt(tcell.Color(197)),
-		MakeTCellColorExt(tcell.Color(198)),
-		MakeTCellColorExt(tcell.Color(199)),
-		MakeTCellColorExt(tcell.Color(200)),
-		MakeTCellColorExt(tcell.Color(201)),
-		MakeTCellColorExt(tcell.Color(202)),
-		MakeTCellColorExt(tcell.Color(203)),
-		MakeTCellColorExt(tcell.Color(204)),
-		MakeTCellColorExt(tcell.Color(205)),
-		MakeTCellColorExt(tcell.Color(206)),
-		MakeTCellColorExt(tcell.Color(207)),
-		MakeTCellColorExt(tcell.Color(208)),
-		MakeTCellColorExt(tcell.Color(209)),
-		MakeTCellColorExt(tcell.Color(210)),
-		MakeTCellColorExt(tcell.Color(211)),
-		MakeTCellColorExt(tcell.Color(212)),
-		MakeTCellColorExt(tcell.Color(213)),
-		MakeTCellColorExt(tcell.Color(214)),
-		MakeTCellColorExt(tcell.Color(215)),
-		MakeTCellColorExt(tcell.Color(216)),
-		MakeTCellColorExt(tcell.Color(217)),
-		MakeTCellColorExt(tcell.Color(218)),
-		MakeTCellColorExt(tcell.Color(219)),
-		MakeTCellColorExt(tcell.Color(220)),
-		MakeTCellColorExt(tcell.Color(221)),
-		MakeTCellColorExt(tcell.Color(222)),
-		MakeTCellColorExt(tcell.Color(223)),
-		MakeTCellColorExt(tcell.Color(224)),
-		MakeTCellColorExt(tcell.Color(225)),
-		MakeTCellColorExt(tcell.Color(226)),
-		MakeTCellColorExt(tcell.Color(227)),
-		MakeTCellColorExt(tcell.Color(228)),
-		MakeTCellColorExt(tcell.Color(229)),
-		MakeTCellColorExt(tcell.Color(230)),
-		MakeTCellColorExt(tcell.Color(231)),
-		MakeTCellColorExt(tcell.Color(232)),
-		MakeTCellColorExt(tcell.Color(233)),
-		MakeTCellColorExt(tcell.Color(234)),
-		MakeTCellColorExt(tcell.Color(235)),
-		MakeTCellColorExt(tcell.Color(236)),
-		MakeTCellColorExt(tcell.Color(237)),
-		MakeTCellColorExt(tcell.Color(238)),
-		MakeTCellColorExt(tcell.Color(239)),
-		MakeTCellColorExt(tcell.Color(240)),
-		MakeTCellColorExt(tcell.Color(241)),
-		MakeTCellColorExt(tcell.Color(242)),
-		MakeTCellColorExt(tcell.Color(243)),
-		MakeTCellColorExt(tcell.Color(244)),
-		MakeTCellColorExt(tcell.Color(245)),
-		MakeTCellColorExt(tcell.Color(246)),
-		MakeTCellColorExt(tcell.Color(247)),
-		MakeTCellColorExt(tcell.Color(248)),
-		MakeTCellColorExt(tcell.Color(249)),
-		MakeTCellColorExt(tcell.Color(250)),
-		MakeTCellColorExt(tcell.Color(251)),
-		MakeTCellColorExt(tcell.Color(252)),
-		MakeTCellColorExt(tcell.Color(253)),
-		MakeTCellColorExt(tcell.Color(254)),
-		MakeTCellColorExt(tcell.Color(255)),
+		MakeTCellColorExt(tcell.Color16),
+		MakeTCellColorExt(tcell.Color17),
+		MakeTCellColorExt(tcell.Color18),
+		MakeTCellColorExt(tcell.Color19),
+		MakeTCellColorExt(tcell.Color20),
+		MakeTCellColorExt(tcell.Color21),
+		MakeTCellColorExt(tcell.Color22),
+		MakeTCellColorExt(tcell.Color23),
+		MakeTCellColorExt(tcell.Color24),
+		MakeTCellColorExt(tcell.Color25),
+		MakeTCellColorExt(tcell.Color26),
+		MakeTCellColorExt(tcell.Color27),
+		MakeTCellColorExt(tcell.Color28),
+		MakeTCellColorExt(tcell.Color29),
+		MakeTCellColorExt(tcell.Color30),
+		MakeTCellColorExt(tcell.Color31),
+		MakeTCellColorExt(tcell.Color32),
+		MakeTCellColorExt(tcell.Color33),
+		MakeTCellColorExt(tcell.Color34),
+		MakeTCellColorExt(tcell.Color35),
+		MakeTCellColorExt(tcell.Color36),
+		MakeTCellColorExt(tcell.Color37),
+		MakeTCellColorExt(tcell.Color38),
+		MakeTCellColorExt(tcell.Color39),
+		MakeTCellColorExt(tcell.Color40),
+		MakeTCellColorExt(tcell.Color41),
+		MakeTCellColorExt(tcell.Color42),
+		MakeTCellColorExt(tcell.Color43),
+		MakeTCellColorExt(tcell.Color44),
+		MakeTCellColorExt(tcell.Color45),
+		MakeTCellColorExt(tcell.Color46),
+		MakeTCellColorExt(tcell.Color47),
+		MakeTCellColorExt(tcell.Color48),
+		MakeTCellColorExt(tcell.Color49),
+		MakeTCellColorExt(tcell.Color50),
+		MakeTCellColorExt(tcell.Color51),
+		MakeTCellColorExt(tcell.Color52),
+		MakeTCellColorExt(tcell.Color53),
+		MakeTCellColorExt(tcell.Color54),
+		MakeTCellColorExt(tcell.Color55),
+		MakeTCellColorExt(tcell.Color56),
+		MakeTCellColorExt(tcell.Color57),
+		MakeTCellColorExt(tcell.Color58),
+		MakeTCellColorExt(tcell.Color59),
+		MakeTCellColorExt(tcell.Color60),
+		MakeTCellColorExt(tcell.Color61),
+		MakeTCellColorExt(tcell.Color62),
+		MakeTCellColorExt(tcell.Color63),
+		MakeTCellColorExt(tcell.Color64),
+		MakeTCellColorExt(tcell.Color65),
+		MakeTCellColorExt(tcell.Color66),
+		MakeTCellColorExt(tcell.Color67),
+		MakeTCellColorExt(tcell.Color68),
+		MakeTCellColorExt(tcell.Color69),
+		MakeTCellColorExt(tcell.Color70),
+		MakeTCellColorExt(tcell.Color71),
+		MakeTCellColorExt(tcell.Color72),
+		MakeTCellColorExt(tcell.Color73),
+		MakeTCellColorExt(tcell.Color74),
+		MakeTCellColorExt(tcell.Color75),
+		MakeTCellColorExt(tcell.Color76),
+		MakeTCellColorExt(tcell.Color77),
+		MakeTCellColorExt(tcell.Color78),
+		MakeTCellColorExt(tcell.Color79),
+		MakeTCellColorExt(tcell.Color80),
+		MakeTCellColorExt(tcell.Color81),
+		MakeTCellColorExt(tcell.Color82),
+		MakeTCellColorExt(tcell.Color83),
+		MakeTCellColorExt(tcell.Color84),
+		MakeTCellColorExt(tcell.Color85),
+		MakeTCellColorExt(tcell.Color86),
+		MakeTCellColorExt(tcell.Color87),
+		MakeTCellColorExt(tcell.Color88),
+		MakeTCellColorExt(tcell.Color89),
+		MakeTCellColorExt(tcell.Color90),
+		MakeTCellColorExt(tcell.Color91),
+		MakeTCellColorExt(tcell.Color92),
+		MakeTCellColorExt(tcell.Color93),
+		MakeTCellColorExt(tcell.Color94),
+		MakeTCellColorExt(tcell.Color95),
+		MakeTCellColorExt(tcell.Color96),
+		MakeTCellColorExt(tcell.Color97),
+		MakeTCellColorExt(tcell.Color98),
+		MakeTCellColorExt(tcell.Color99),
+		MakeTCellColorExt(tcell.Color100),
+		MakeTCellColorExt(tcell.Color101),
+		MakeTCellColorExt(tcell.Color102),
+		MakeTCellColorExt(tcell.Color103),
+		MakeTCellColorExt(tcell.Color104),
+		MakeTCellColorExt(tcell.Color105),
+		MakeTCellColorExt(tcell.Color106),
+		MakeTCellColorExt(tcell.Color107),
+		MakeTCellColorExt(tcell.Color108),
+		MakeTCellColorExt(tcell.Color109),
+		MakeTCellColorExt(tcell.Color110),
+		MakeTCellColorExt(tcell.Color111),
+		MakeTCellColorExt(tcell.Color112),
+		MakeTCellColorExt(tcell.Color113),
+		MakeTCellColorExt(tcell.Color114),
+		MakeTCellColorExt(tcell.Color115),
+		MakeTCellColorExt(tcell.Color116),
+		MakeTCellColorExt(tcell.Color117),
+		MakeTCellColorExt(tcell.Color118),
+		MakeTCellColorExt(tcell.Color119),
+		MakeTCellColorExt(tcell.Color120),
+		MakeTCellColorExt(tcell.Color121),
+		MakeTCellColorExt(tcell.Color122),
+		MakeTCellColorExt(tcell.Color123),
+		MakeTCellColorExt(tcell.Color124),
+		MakeTCellColorExt(tcell.Color125),
+		MakeTCellColorExt(tcell.Color126),
+		MakeTCellColorExt(tcell.Color127),
+		MakeTCellColorExt(tcell.Color128),
+		MakeTCellColorExt(tcell.Color129),
+		MakeTCellColorExt(tcell.Color130),
+		MakeTCellColorExt(tcell.Color131),
+		MakeTCellColorExt(tcell.Color132),
+		MakeTCellColorExt(tcell.Color133),
+		MakeTCellColorExt(tcell.Color134),
+		MakeTCellColorExt(tcell.Color135),
+		MakeTCellColorExt(tcell.Color136),
+		MakeTCellColorExt(tcell.Color137),
+		MakeTCellColorExt(tcell.Color138),
+		MakeTCellColorExt(tcell.Color139),
+		MakeTCellColorExt(tcell.Color140),
+		MakeTCellColorExt(tcell.Color141),
+		MakeTCellColorExt(tcell.Color142),
+		MakeTCellColorExt(tcell.Color143),
+		MakeTCellColorExt(tcell.Color144),
+		MakeTCellColorExt(tcell.Color145),
+		MakeTCellColorExt(tcell.Color146),
+		MakeTCellColorExt(tcell.Color147),
+		MakeTCellColorExt(tcell.Color148),
+		MakeTCellColorExt(tcell.Color149),
+		MakeTCellColorExt(tcell.Color150),
+		MakeTCellColorExt(tcell.Color151),
+		MakeTCellColorExt(tcell.Color152),
+		MakeTCellColorExt(tcell.Color153),
+		MakeTCellColorExt(tcell.Color154),
+		MakeTCellColorExt(tcell.Color155),
+		MakeTCellColorExt(tcell.Color156),
+		MakeTCellColorExt(tcell.Color157),
+		MakeTCellColorExt(tcell.Color158),
+		MakeTCellColorExt(tcell.Color159),
+		MakeTCellColorExt(tcell.Color160),
+		MakeTCellColorExt(tcell.Color161),
+		MakeTCellColorExt(tcell.Color162),
+		MakeTCellColorExt(tcell.Color163),
+		MakeTCellColorExt(tcell.Color164),
+		MakeTCellColorExt(tcell.Color165),
+		MakeTCellColorExt(tcell.Color166),
+		MakeTCellColorExt(tcell.Color167),
+		MakeTCellColorExt(tcell.Color168),
+		MakeTCellColorExt(tcell.Color169),
+		MakeTCellColorExt(tcell.Color170),
+		MakeTCellColorExt(tcell.Color171),
+		MakeTCellColorExt(tcell.Color172),
+		MakeTCellColorExt(tcell.Color173),
+		MakeTCellColorExt(tcell.Color174),
+		MakeTCellColorExt(tcell.Color175),
+		MakeTCellColorExt(tcell.Color176),
+		MakeTCellColorExt(tcell.Color177),
+		MakeTCellColorExt(tcell.Color178),
+		MakeTCellColorExt(tcell.Color179),
+		MakeTCellColorExt(tcell.Color180),
+		MakeTCellColorExt(tcell.Color181),
+		MakeTCellColorExt(tcell.Color182),
+		MakeTCellColorExt(tcell.Color183),
+		MakeTCellColorExt(tcell.Color184),
+		MakeTCellColorExt(tcell.Color185),
+		MakeTCellColorExt(tcell.Color186),
+		MakeTCellColorExt(tcell.Color187),
+		MakeTCellColorExt(tcell.Color188),
+		MakeTCellColorExt(tcell.Color189),
+		MakeTCellColorExt(tcell.Color190),
+		MakeTCellColorExt(tcell.Color191),
+		MakeTCellColorExt(tcell.Color192),
+		MakeTCellColorExt(tcell.Color193),
+		MakeTCellColorExt(tcell.Color194),
+		MakeTCellColorExt(tcell.Color195),
+		MakeTCellColorExt(tcell.Color196),
+		MakeTCellColorExt(tcell.Color197),
+		MakeTCellColorExt(tcell.Color198),
+		MakeTCellColorExt(tcell.Color199),
+		MakeTCellColorExt(tcell.Color200),
+		MakeTCellColorExt(tcell.Color201),
+		MakeTCellColorExt(tcell.Color202),
+		MakeTCellColorExt(tcell.Color203),
+		MakeTCellColorExt(tcell.Color204),
+		MakeTCellColorExt(tcell.Color205),
+		MakeTCellColorExt(tcell.Color206),
+		MakeTCellColorExt(tcell.Color207),
+		MakeTCellColorExt(tcell.Color208),
+		MakeTCellColorExt(tcell.Color209),
+		MakeTCellColorExt(tcell.Color210),
+		MakeTCellColorExt(tcell.Color211),
+		MakeTCellColorExt(tcell.Color212),
+		MakeTCellColorExt(tcell.Color213),
+		MakeTCellColorExt(tcell.Color214),
+		MakeTCellColorExt(tcell.Color215),
+		MakeTCellColorExt(tcell.Color216),
+		MakeTCellColorExt(tcell.Color217),
+		MakeTCellColorExt(tcell.Color218),
+		MakeTCellColorExt(tcell.Color219),
+		MakeTCellColorExt(tcell.Color220),
+		MakeTCellColorExt(tcell.Color221),
+		MakeTCellColorExt(tcell.Color222),
+		MakeTCellColorExt(tcell.Color223),
+		MakeTCellColorExt(tcell.Color224),
+		MakeTCellColorExt(tcell.Color225),
+		MakeTCellColorExt(tcell.Color226),
+		MakeTCellColorExt(tcell.Color227),
+		MakeTCellColorExt(tcell.Color228),
+		MakeTCellColorExt(tcell.Color229),
+		MakeTCellColorExt(tcell.Color230),
+		MakeTCellColorExt(tcell.Color231),
+		MakeTCellColorExt(tcell.Color232),
+		MakeTCellColorExt(tcell.Color233),
+		MakeTCellColorExt(tcell.Color234),
+		MakeTCellColorExt(tcell.Color235),
+		MakeTCellColorExt(tcell.Color236),
+		MakeTCellColorExt(tcell.Color237),
+		MakeTCellColorExt(tcell.Color238),
+		MakeTCellColorExt(tcell.Color239),
+		MakeTCellColorExt(tcell.Color240),
+		MakeTCellColorExt(tcell.Color241),
+		MakeTCellColorExt(tcell.Color242),
+		MakeTCellColorExt(tcell.Color243),
+		MakeTCellColorExt(tcell.Color244),
+		MakeTCellColorExt(tcell.Color245),
+		MakeTCellColorExt(tcell.Color246),
+		MakeTCellColorExt(tcell.Color247),
+		MakeTCellColorExt(tcell.Color248),
+		MakeTCellColorExt(tcell.Color249),
+		MakeTCellColorExt(tcell.Color250),
+		MakeTCellColorExt(tcell.Color251),
+		MakeTCellColorExt(tcell.Color252),
+		MakeTCellColorExt(tcell.Color253),
+		MakeTCellColorExt(tcell.Color254),
+		MakeTCellColorExt(tcell.Color255),
 	}
 
 	term2Cache               *lru.Cache
@@ -1013,7 +1013,7 @@ func MakeCellStyle(fg TCellColor, bg TCellColor, attr StyleAttrs) tcell.Style {
 		bgt = bg.ToTCell()
 	}
 	st := StyleNone.MergeUnder(attr)
-	return tcell.Style(st.OnOff).Foreground(fgt).Background(bgt)
+	return tcell.Style{}.Attributes(st.OnOff).Foreground(fgt).Background(bgt)
 }
 
 //======================================================================
@@ -1206,7 +1206,7 @@ func (r RGBColor) findClosest(from []colorful.Color, corresponding []TCellColor,
 func (r RGBColor) ToTCellColor(mode ColorMode) (TCellColor, bool) {
 	switch mode {
 	case Mode24BitColors:
-		c := tcell.Color((r.Red << 16) | (r.Green << 8) | (r.Blue << 0) | int(tcell.ColorIsRGB))
+		c := tcell.NewRGBColor(int32(r.Red), int32(r.Green), int32(r.Blue))
 		return MakeTCellColorExt(c), true
 	case Mode256Colors:
 		if IgnoreBase16 {
@@ -1218,7 +1218,7 @@ func (r RGBColor) ToTCellColor(mode ColorMode) (TCellColor, bool) {
 		rd := cubeLookup88_16[r.Red>>4]
 		g := cubeLookup88_16[r.Green>>4]
 		b := cubeLookup88_16[r.Blue>>4]
-		c := tcell.Color((CubeStart + (((rd * cubeSize88) + g) * cubeSize88) + b) + 0)
+		c := tcell.Color((CubeStart + (((rd * cubeSize88) + g) * cubeSize88) + b) + 0) + tcell.ColorValid
 		return MakeTCellColorExt(c), true
 	case Mode16Colors:
 		return r.findClosest(colorful16, term16, term16Cache), true
@@ -1300,9 +1300,12 @@ func (s *UrwidColor) ToTCellColor(mode ColorMode) (TCellColor, bool) {
 		panic(errors.WithStack(InvalidColor{Color: s}))
 	}
 
-	idx = idx - 1 // offset for tcell, which stores default at -1
-
-	c := MakeTCellColorExt(tcell.Color(idx))
+	col := tcell.ColorDefault
+	if idx > 0 {
+		idx = idx - 1
+		col = tcell.ColorValid + tcell.Color(idx)
+	}
+	c := MakeTCellColorExt(col)
 
 	switch mode {
 	case Mode24BitColors, Mode256Colors, Mode88Colors, Mode16Colors:
@@ -1392,13 +1395,13 @@ func (s GrayColor) ToTCellColor(mode ColorMode) (TCellColor, bool) {
 	switch mode {
 	case Mode24BitColors:
 		adj := intScale(s.Val, 101, 0x100)
-		c := tcell.Color((adj << 16) | (adj << 8) | (adj << 0) | int(tcell.ColorIsRGB))
+		c := tcell.NewRGBColor(int32(adj), int32(adj), int32(adj))
 		return MakeTCellColorExt(c), true
 	case Mode256Colors:
-		x := tcell.Color(grayAdjustment256(grayLookup256_101[s.Val]) + 1)
+		x := tcell.Color(grayAdjustment256(grayLookup256_101[s.Val]) + 1) + tcell.ColorValid
 		return MakeTCellColorExt(x), true
 	case Mode88Colors:
-		x := tcell.Color(grayAdjustment88(grayLookup88_101[s.Val]) + 1)
+		x := tcell.Color(grayAdjustment88(grayLookup88_101[s.Val]) + 1) + tcell.ColorValid
 		return MakeTCellColorExt(x), true
 	default:
 		panic(errors.WithStack(ColorModeMismatch{Color: s, Mode: mode}))
@@ -1408,17 +1411,11 @@ func (s GrayColor) ToTCellColor(mode ColorMode) (TCellColor, bool) {
 //======================================================================
 
 // TCellColor is an IColor using tcell's color primitives. If you are not porting from urwid or translating
-// from urwid, this is the simplest approach to using color. Note that the underlying tcell.Color value is
-// stored offset by 2 from the value tcell would use to actually render a colored cell. Tcell represents
-// e.g. black by 0, maroon by 1, and so on - that means the default/empty/zero value for a tcell.Color object
-// is the color black. Gowid's layering approach means that the empty value for a color should mean "no color
-// preference" - so we want the zero value to mean that. A tcell.Color of -1 means "default color". So gowid
-// coopts -2 to mean "no color preference". We store the tcell.Color offset by 2 so the empty value for a
-// TCellColor means "no color preference". When we convert to a tcell.Color, we subtract 2 (but since a value
-// of -2 is meaningless to tcell, the caller should check and not pass on a value of -2 to tcell APIs - see
-// gowid.ColorNone)
+// from urwid, this is the simplest approach to using color. Gowid's layering approach means that the empty
+// value for a color should mean "no color preference" - so we want the zero value to mean that. A tcell.Color
+// of 0 means "default color". So gowid coopts nil to mean "no color preference".
 type TCellColor struct {
-	tc tcell.Color
+	tc *tcell.Color
 }
 
 var (
@@ -1434,7 +1431,10 @@ func MakeTCellColor(val string) (TCellColor, error) {
 	match := tcellColorRE.FindStringSubmatch(val) // e.g. "Color00"
 	if len(match) == 2 {
 		n, _ := strconv.ParseUint(match[1], 16, 8)
-		return MakeTCellColorExt(tcell.Color(n)), nil
+		if n == 0 {
+			return MakeTCellColorExt(tcell.ColorDefault), nil
+		}
+		return MakeTCellColorExt(tcell.Color(n) + tcell.ColorValid), nil
 	} else if col, ok := tcell.ColorNames[val]; !ok {
 		return TCellColor{}, errors.WithStack(InvalidColor{Color: val})
 	} else {
@@ -1444,37 +1444,32 @@ func MakeTCellColor(val string) (TCellColor, error) {
 
 // MakeTCellColor returns an initialized TCellColor given a tcell.Color input. The values that can be
 // used are provided here: https://github.com/gdamore/tcell/blob/master/color.go#L41.
-func MakeTCellColorSafe(val tcell.Color) (TCellColor, error) {
-	return TCellColor{val + 2}, nil
-}
-
-// MakeTCellColor returns an initialized TCellColor given a tcell.Color input. The values that can be
-// used are provided here: https://github.com/gdamore/tcell/blob/master/color.go#L41.
 func MakeTCellColorExt(val tcell.Color) TCellColor {
-	res, _ := MakeTCellColorSafe(val)
-	return res
+	return TCellColor{&val}
 }
 
 // MakeTCellNoColor returns an initialized TCellColor that represents "no color" - meaning if another
 // color is rendered "under" this one, then the color underneath will be displayed.
 func MakeTCellNoColor() TCellColor {
-	res := MakeTCellColorExt(-2)
-	return res
+	return TCellColor{}
 }
 
 // String implements Stringer for '%v' support.
 func (r TCellColor) String() string {
-	c := r.tc - 2
-	if c == -2 {
+	if r.tc == nil {
 		return "[no-color]"
 	} else {
+		c := *r.tc
 		return fmt.Sprintf("TCellColor(%v)", tcell.Color(c))
 	}
 }
 
 // ToTCell converts a TCellColor back to a tcell.Color for passing to tcell APIs.
 func (r TCellColor) ToTCell() tcell.Color {
-	return r.tc - 2
+	if r.tc == nil {
+		return tcell.ColorDefault
+	}
+	return *r.tc
 }
 
 // ToTCellColor is a no-op, and exists so that TCellColor conforms to the IColor interface.

--- a/decoration_test.go
+++ b/decoration_test.go
@@ -6,7 +6,7 @@ package gowid
 import (
 	"testing"
 
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +18,7 @@ func TestColor1(t *testing.T) {
 	i2 := i2a.ToTCell()
 	// See https://jonasjacek.github.io/colors/ - we are skipping
 	// colors 0-21 inclusive
-	if i2 != 232 {
+	if i2 != tcell.Color232 {
 		t.Errorf("Failed")
 	}
 }
@@ -28,7 +28,7 @@ func TestColor1b(t *testing.T) {
 	c, _ := MakeRGBColorExtSafe(0, 0, 0)
 	i2a, _ := c.ToTCellColor(Mode256Colors)
 	i2 := i2a.ToTCell()
-	if i2 != 0 {
+	if i2 != tcell.ColorValid {
 		t.Errorf("Failed")
 	}
 }
@@ -37,7 +37,7 @@ func TestColor2(t *testing.T) {
 	c := NewUrwidColor("dark red")
 	i2a, _ := c.ToTCellColor(Mode256Colors)
 	i2 := i2a.ToTCell()
-	if i2 != 2-1 {
+	if i2 != tcell.ColorMaroon {
 		t.Errorf("Failed")
 	}
 }
@@ -61,7 +61,7 @@ func TestColor5(t *testing.T) {
 	if c.Val != 100 {
 		t.Errorf("Failed")
 	}
-	if v, _ := c.ToTCellColor(Mode256Colors); v.ToTCell() != 232 {
+	if v, _ := c.ToTCellColor(Mode256Colors); v.ToTCell() != tcell.Color232 {
 		t.Errorf("Failed")
 	}
 }
@@ -71,7 +71,7 @@ func TestColor6(t *testing.T) {
 	if c.Val != 3 {
 		t.Errorf("Failed")
 	}
-	if v, _ := c.ToTCellColor(Mode256Colors); v.ToTCell() != 233 {
+	if v, _ := c.ToTCellColor(Mode256Colors); v.ToTCell() != tcell.Color233 {
 		t.Errorf("Failed")
 	}
 }
@@ -81,7 +81,7 @@ func TestColor7(t *testing.T) {
 	if c.Val != 0 {
 		t.Errorf("Failed")
 	}
-	if v, _ := c.ToTCellColor(Mode256Colors); v.ToTCell() != 17 {
+	if v, _ := c.ToTCellColor(Mode256Colors); v.ToTCell() != tcell.Color17 {
 		t.Errorf("Failed")
 	}
 }
@@ -134,13 +134,13 @@ func TestStringColor3(t *testing.T) {
 func TestGray881(t *testing.T) {
 	c := MakeGrayColor("g100")
 	v, _ := c.ToTCellColor(Mode88Colors)
-	assert.Equal(t, v.ToTCell(), tcell.Color(80))
+	assert.Equal(t, v.ToTCell(), tcell.Color80)
 }
 
 func TestDefault1(t *testing.T) {
 	c, _ := MakeColorSafe("default")
 	v, _ := c.ToTCellColor(Mode256Colors)
-	assert.Equal(t, v.ToTCell(), tcell.Color(-1))
+	assert.Equal(t, v.ToTCell(), tcell.ColorDefault)
 }
 
 func TestTCell1(t *testing.T) {
@@ -150,7 +150,7 @@ func TestTCell1(t *testing.T) {
 }
 
 func TestTCell2(t *testing.T) {
-	c, _ := MakeTCellColorSafe(tcell.ColorMaroon)
+	c := MakeTCellColorExt(tcell.ColorMaroon)
 	v, _ := c.ToTCellColor(Mode256Colors)
 	assert.Equal(t, v.ToTCell(), tcell.ColorMaroon)
 }

--- a/examples/gowid-dir/dir.go
+++ b/examples/gowid-dir/dir.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/tree"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/gowid-editor/editor.go
+++ b/examples/gowid-editor/editor.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/vscroll"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/gowid-menu/menu.go
+++ b/examples/gowid-menu/menu.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/vpadding"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/gowid-overlay1/overlay1.go
+++ b/examples/gowid-overlay1/overlay1.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gcla/gowid/widgets/fill"
 	"github.com/gcla/gowid/widgets/overlay"
 	"github.com/gcla/gowid/widgets/styled"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/gowid-overlay2/overlay2.go
+++ b/examples/gowid-overlay2/overlay2.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/vpadding"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	asc "github.com/guptarohit/asciigraph"
 	log "github.com/sirupsen/logrus"
 )

--- a/examples/gowid-overlay3/overlay3.go
+++ b/examples/gowid-overlay3/overlay3.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gcla/gowid/widgets/overlay"
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/gowid-palette/palette.go
+++ b/examples/gowid-palette/palette.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gcla/gowid/widgets/radio"
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/gowid-table/table.go
+++ b/examples/gowid-table/table.go
@@ -18,7 +18,7 @@ import (
 	_ "github.com/gcla/gowid/examples/gowid-table/statik"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/rakyll/statik/fs"
 	log "github.com/sirupsen/logrus"
 

--- a/examples/gowid-terminal/terminal.go
+++ b/examples/gowid-terminal/terminal.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/terminal"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/gowid-tree/tree.go
+++ b/examples/gowid-tree/tree.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/tree"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/examples/gowid-tutorial2/tutorial2.go
+++ b/examples/gowid-tutorial2/tutorial2.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/examples"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/examples/gowid-tutorial4/tutorial4.go
+++ b/examples/gowid-tutorial4/tutorial4.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gcla/gowid/examples"
 	"github.com/gcla/gowid/widgets/edit"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/examples/gowid-tutorial6/tutorial6.go
+++ b/examples/gowid-tutorial6/tutorial6.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gcla/gowid/widgets/list"
 	"github.com/gcla/gowid/widgets/pile"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/examples/gowid-widgets1/widgets1.go
+++ b/examples/gowid-widgets1/widgets1.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/vpadding"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/araddon/dateparse v0.0.0-20210207001429-0eec95c9db7e
 	github.com/creack/pty v1.1.15
-	github.com/gdamore/tcell v1.3.1-0.20200115030318-bff4943f9a29
+	github.com/gdamore/tcell/v2 v2.4.0
 	github.com/go-test/deep v1.0.1
 	github.com/guptarohit/asciigraph v0.4.1
 	github.com/hashicorp/golang-lru v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/gdamore/tcell v1.3.1-0.20200115030318-bff4943f9a29 h1:kvzEHvL4/ORuWe6JN6WeaiRYIvVDUVaC2r0gpJIxJ6I=
-github.com/gdamore/tcell v1.3.1-0.20200115030318-bff4943f9a29/go.mod h1:vxEiSDZdW3L+Uhjii9c3375IlDmR05bzxY404ZVSMo0=
+github.com/gdamore/tcell/v2 v2.4.0 h1:W6dxJEmaxYvhICFoTY3WrLLEXsQ11SaFnKGVEXW57KM=
+github.com/gdamore/tcell/v2 v2.4.0/go.mod h1:cTTuF84Dlj/RqmaCIV5p4w8uG1zWdk0SF6oBpwHp4fU=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/guptarohit/asciigraph v0.4.1 h1:YHmCMN8VH81BIUIgTg2Fs3B52QDxNZw2RQ6j5pGoSxo=
@@ -24,7 +24,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -44,8 +43,10 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756 h1:9nuHUbU8dRnRRfj9KjWUVrJeoexdbeMjttk6Oh1rD10=
-golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/gwtest/testutils.go
+++ b/gwtest/testutils.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/support.go
+++ b/support.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/pkg/errors"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/vim/vim.go
+++ b/vim/vim.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/vim/vim_test.go
+++ b/vim/vim_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/boxadapter/boxadapter.go
+++ b/widgets/boxadapter/boxadapter.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/boxadapter/boxadapter_test.go
+++ b/widgets/boxadapter/boxadapter_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gcla/gowid/gwtest"
 	"github.com/gcla/gowid/widgets/edit"
 	"github.com/gcla/gowid/widgets/list"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/button/button.go
+++ b/widgets/button/button.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/clicktracker/clicktracker.go
+++ b/widgets/clicktracker/clicktracker.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/columns/columns.go
+++ b/widgets/columns/columns.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gcla/gowid/gwutil"
 	"github.com/gcla/gowid/vim"
 	"github.com/gcla/gowid/widgets/fill"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/columns/columns_test.go
+++ b/widgets/columns/columns_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gcla/gowid/widgets/fill"
 	"github.com/gcla/gowid/widgets/selectable"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/dialog/dialog.go
+++ b/widgets/dialog/dialog.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gcla/gowid/widgets/shadow"
 	"github.com/gcla/gowid/widgets/styled"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/edit/edit.go
+++ b/widgets/edit/edit.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/pkg/errors"
 )
 

--- a/widgets/edit/edit_test.go
+++ b/widgets/edit/edit_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwtest"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/fixedadapter/fixedadapter.go
+++ b/widgets/fixedadapter/fixedadapter.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/framed/framed.go
+++ b/widgets/framed/framed.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/mattn/go-runewidth"
 )
 

--- a/widgets/grid/grid.go
+++ b/widgets/grid/grid.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gcla/gowid/widgets/pile"
 	"github.com/gcla/gowid/widgets/text"
 	"github.com/gcla/gowid/widgets/vpadding"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/grid/grid_test.go
+++ b/widgets/grid/grid_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gcla/gowid/gwtest"
 	"github.com/gcla/gowid/widgets/button"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/hpadding/hpadding.go
+++ b/widgets/hpadding/hpadding.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/hpadding/hpadding_test.go
+++ b/widgets/hpadding/hpadding_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gcla/gowid/widgets/checkbox"
 	"github.com/gcla/gowid/widgets/fill"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/widgets/keypress/keypress.go
+++ b/widgets/keypress/keypress.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/list/list.go
+++ b/widgets/list/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
 	"github.com/gcla/gowid/vim"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/pkg/errors"
 )
 

--- a/widgets/list/list_test.go
+++ b/widgets/list/list_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gcla/gowid/widgets/pile"
 	"github.com/gcla/gowid/widgets/selectable"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/widgets/menu/menu.go
+++ b/widgets/menu/menu.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gcla/gowid/widgets/holder"
 	"github.com/gcla/gowid/widgets/null"
 	"github.com/gcla/gowid/widgets/overlay"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/overlay/overlay.go
+++ b/widgets/overlay/overlay.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/widgets/padding"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/padding/padding.go
+++ b/widgets/padding/padding.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
 	"github.com/gcla/gowid/widgets/fill"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/padding/padding_test.go
+++ b/widgets/padding/padding_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gcla/gowid/widgets/fill"
 	"github.com/gcla/gowid/widgets/framed"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/pile/pile.go
+++ b/widgets/pile/pile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
 	"github.com/gcla/gowid/vim"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/pile/pile_test.go
+++ b/widgets/pile/pile_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gcla/gowid/widgets/list"
 	"github.com/gcla/gowid/widgets/selectable"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/shadow/shadow.go
+++ b/widgets/shadow/shadow.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/table/table.go
+++ b/widgets/table/table.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gcla/gowid/widgets/isselected"
 	"github.com/gcla/gowid/widgets/list"
 	"github.com/gcla/gowid/widgets/pile"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	lru "github.com/hashicorp/golang-lru"
 )
 

--- a/widgets/table/table_test.go
+++ b/widgets/table/table_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gcla/gowid/widgets/fill"
 	"github.com/gcla/gowid/widgets/selectable"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/widgets/terminal/term_canvas.go
+++ b/widgets/terminal/term_canvas.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/mattn/go-runewidth"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/text/encoding/charmap"
@@ -1296,10 +1296,10 @@ func (c *Canvas) SetRune(r rune) {
 func (c *Canvas) MakeCellFrom(r rune) gowid.Cell {
 	var cell gowid.Cell = gowid.MakeCell(r, gowid.MakeTCellColorExt(tcell.ColorDefault), gowid.MakeTCellColorExt(tcell.ColorDefault), gowid.StyleNone)
 	if !c.fg.IsNone() {
-		cell = cell.WithForegroundColor(gowid.MakeTCellColorExt(tcell.Color(c.fg.Val() - 1)))
+		cell = cell.WithForegroundColor(gowid.MakeTCellColorExt(tcell.Color(c.fg.Val() - 1) + tcell.ColorValid))
 	}
 	if !c.bg.IsNone() {
-		cell = cell.WithBackgroundColor(gowid.MakeTCellColorExt(tcell.Color(c.bg.Val() - 1)))
+		cell = cell.WithBackgroundColor(gowid.MakeTCellColorExt(tcell.Color(c.bg.Val() - 1) + tcell.ColorValid))
 	}
 	if len(c.styles) > 0 {
 		for k, _ := range c.styles {

--- a/widgets/terminal/terminal.go
+++ b/widgets/terminal/terminal.go
@@ -20,9 +20,9 @@ import (
 	"github.com/creack/pty"
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
-	"github.com/gdamore/tcell/terminfo"
-	"github.com/gdamore/tcell/terminfo/dynamic"
+	tcell "github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/terminfo"
+	"github.com/gdamore/tcell/v2/terminfo/dynamic"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/widgets/terminal/terminal_test.go
+++ b/widgets/terminal/terminal_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
-	"github.com/gdamore/tcell/terminfo"
+	tcell "github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/terminfo"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/widgets/terminal/utils.go
+++ b/widgets/terminal/utils.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
-	"github.com/gdamore/tcell/terminfo"
+	tcell "github.com/gdamore/tcell/v2"
+	"github.com/gdamore/tcell/v2/terminfo"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/widgets/text/testwidget.go
+++ b/widgets/text/testwidget.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/gcla/gowid"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/vpadding/vpadding.go
+++ b/widgets/vpadding/vpadding.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/widgets/fill"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================

--- a/widgets/vpadding/vpadding_test.go
+++ b/widgets/vpadding/vpadding_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gcla/gowid/widgets/fill"
 	"github.com/gcla/gowid/widgets/pile"
 	"github.com/gcla/gowid/widgets/text"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/widgets/vscroll/vscroll.go
+++ b/widgets/vscroll/vscroll.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gcla/gowid"
 	"github.com/gcla/gowid/gwutil"
-	"github.com/gdamore/tcell"
+	tcell "github.com/gdamore/tcell/v2"
 )
 
 //======================================================================


### PR DESCRIPTION
I wanted to use both `gowid` and `tcell/v2`.

## tcell/v2 changes relevant to gowid
- Style is now a struct, mask moved to `(Style).Attributes`
- Color moved from int to uint64, default is 0, colors starts from `1 << 32`. e.g. `ColorBlack = 1 + 1 << 32`. `1 << 32` also acts as a bit flag for a "valid color" as noted by `tcell.ColorValid`.

## gowid changes
- The `-2` offset was removed, since color is now a `uint64` and `tcell.ColorDefault` is now 0 there are better ways of translation.
- Previously, the zero value for `gowid.TCellColor` is 0, which offsets to -2 and means no color. When canvas `gowid.Cell` is instantiated like in `emptyLines` or other cases where `Cell{}` is created directly, they have the zero value for `gowid.TCellColor`. Since `-2` offset was removed, I changed the underlying `tcell.Color` to a pointer to indicate `ColorNone`.