### PR TITLE
Fix widthhelper not updating array size when setting subwidgets

### DIFF
--- a/widgets/columns/columns.go
+++ b/widgets/columns/columns.go
@@ -163,6 +163,8 @@ func (w *Widget) SetSubWidgets(widgets []gowid.IWidget, app gowid.IApp) {
 			ws[i] = &gowid.ContainerWidget{IWidget: iw, D: gowid.RenderFlow{}}
 		}
 	}
+	w.widthHelper = make([]bool, len(widgets))
+	w.widthHelper2 = make([]bool, len(widgets))
 	oldFocus := w.Focus()
 	w.widgets = ws
 	w.SetFocus(app, oldFocus)


### PR DESCRIPTION
Without this fix, using `(*columns.Widget).SetSubwidgets` will cause a panic during render because `widthHelpers` still has the same array size when the columns widget was instantiated by `columns.New`.