### PR TITLE
Column and pile SetSubWidget should trigger OnFocusCallbacks

### DIFF
--- a/widgets/columns/columns.go
+++ b/widgets/columns/columns.go
@@ -164,6 +164,7 @@ func (w *Widget) SetSubWidgets(widgets []gowid.IWidget, app gowid.IApp) {
 		}
 	}
 	oldFocus := w.Focus()
+	w.focus = -1
 	w.widgets = ws
 	w.SetFocus(app, oldFocus)
 	gowid.RunWidgetCallbacks(w.Callbacks, gowid.SubWidgetsCB{}, app, w)

--- a/widgets/pile/pile.go
+++ b/widgets/pile/pile.go
@@ -161,6 +161,7 @@ func (w *Widget) SetSubWidgets(widgets []gowid.IWidget, app gowid.IApp) {
 		}
 	}
 	oldFocus := w.Focus()
+	w.focus = -1
 	w.widgets = ws
 	w.SetFocus(app, oldFocus)
 	gowid.RunWidgetCallbacks(w.Callbacks, gowid.SubWidgetsCB{}, app, w)


### PR DESCRIPTION
This one might be controversial, OK to work around this another way.

When setting subwidgets to a column and pile and the length of existing subwidgets is same or more, then `SetSubWidgets` does not trigger focus callbacks because old focus == new focus.

When subwidgets have been removed, it does trigger because of the new focus value is clamped between `[0, len(widgets) -1]`.

However, when subwidgets are set, its not necessarily the same subwidgets. I propose that we trigger focus callbacks always when subwidgets are set so that its behavior is more consistent.