### PR TITLE
Add missing mutex unlock in terminal.go

### DIFF
--- a/widgets/terminal/terminal.go
+++ b/widgets/terminal/terminal.go
@@ -827,6 +827,7 @@ func findTerminfo(name string) (*terminfo.Terminfo, error) {
 		return ti, nil
 	}
 	ti, e = terminfo.LookupTerminfo(name)
+	cachedTerminfoMutex.Unlock()
 	return ti, e
 }
 


### PR DESCRIPTION
I ran into an issue where my program would enter deadlock during a call to `terminal.NewExt`. I traced the issue down to a missing mutex unlock in `findTerminfo`.